### PR TITLE
Fix: improve windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.1.0
+
+### Fixed
+
+- Fix script execution on Windows.
+- Fix error message on Windows suggestion wrong pub cache path.
+
+### Changed
+
+- (Internal) `HostPlatformConfiguration` added to configure certain runtime variables such as the pub cache location and flutterfire command to ensure correct cross-platform execution.
+
 ## 3.0.0
 
 ### Breaking Changes

--- a/bin/src/services/firebase_service.dart
+++ b/bin/src/services/firebase_service.dart
@@ -5,6 +5,7 @@ import '../logger.dart';
 import '../models/flavor_config.dart';
 import '../models/global_config.dart';
 import '../utils/process_runner.dart';
+import '../utils/host_platform.dart';
 
 /// Service for interacting with the Firebase CLI (flutterfire).
 class FirebaseService {
@@ -65,7 +66,7 @@ class FirebaseService {
     Process process;
     try {
       process = await _processRunner.start(
-        'flutterfire',
+        HostPlatformConfig.flutterfireCli,
         args,
         mode: ProcessStartMode.inheritStdio,
       );
@@ -76,7 +77,7 @@ class FirebaseService {
       );
       logInfo('Install it with: dart pub global activate flutterfire_cli');
       logInfo(
-        'Then ensure your PATH includes: ${Platform.environment['HOME'] ?? Platform.environment['USERPROFILE']}/.pub-cache/bin',
+        'Then ensure your PATH includes: ${HostPlatformConfig.pubCacheLocation}',
       );
       throw FirebaseFlavorsException('Failed to start flutterfire command.');
     }

--- a/bin/src/utils/exceptions.dart
+++ b/bin/src/utils/exceptions.dart
@@ -1,0 +1,2 @@
+/// Thrown when an unknown platform is attempting to run an OS-sensitive operation.
+class UnknownPlatformException extends Exeption { }

--- a/bin/src/utils/exceptions.dart
+++ b/bin/src/utils/exceptions.dart
@@ -1,9 +1,14 @@
-import 'dart:io';
+import 'package:platform/platform.dart';
 
 /// Thrown when an unknown platform is attempting to run an OS-sensitive operation.
 class UnknownPlatformException implements Exception {
+  const UnknownPlatformException(this.platform);
+
+  /// The OS that was used when the exception was thrown.
+  final Platform platform;
+
   @override
   String toString() {
-    return 'Unknown platform exception - ${Platform.operatingSystem}';
+    return 'Unknown platform exception - ${platform.operatingSystem}';
   }
 }

--- a/bin/src/utils/exceptions.dart
+++ b/bin/src/utils/exceptions.dart
@@ -1,2 +1,9 @@
+import 'dart:io';
+
 /// Thrown when an unknown platform is attempting to run an OS-sensitive operation.
-class UnknownPlatformException extends Exeption { }
+class UnknownPlatformException implements Exception {
+  @override
+  String toString() {
+    return 'Unknown platform exception - ${Platform.operatingSystem}';
+  }
+}

--- a/bin/src/utils/host_platform.dart
+++ b/bin/src/utils/host_platform.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+/// Operating System-specific constants for terminal commands, directories, etc.
+///
+/// Supports Windows, Mac, and Linux hosts. Others will throw an [UnknownPlatformException].
+abstract class HostPlatformConfig {
+
+    /// Returns the expected location for the dart pub cache.
+    ///
+    /// * For Unix systems this is usually a hidden folder in your home directory.
+    /// * For Windows this is usually in your AppData folder.
+    static String pubCacheLocation() {
+        if (Platform.isWindows) {
+            return '%APPDATA%/Pub/Cache/bin';
+        } else if (Platform.isMac || Platform.isLinux) {
+            return '~/.pub/cache/bin';   
+        } else {
+            throw UnknownPlatformException('Unknown platform - ${Platform.operatingSystem}');
+        }
+    }
+
+    /// Returns the expected name of the `flutterfire_cli` command.
+    ///
+    /// * For Unix systems this is usually just `flutterfire`.
+    /// * For Windows this is usually `flutterfire.bat`, but powershell terminals allow the Unix method, too.
+    static String flutterfireCli() {
+        if (Platform.isWindows) {
+            return 'flutterfire.bat';    
+        } else if (Platform.isMac || Platform.isLinux) {
+            return 'flutterfire';        
+        } else {
+            throw UnknownPlatformException('Unknown platform - ${Platform.operatingSystem}');
+        }
+    }
+}
+

--- a/bin/src/utils/host_platform.dart
+++ b/bin/src/utils/host_platform.dart
@@ -1,35 +1,51 @@
-import 'dart:io';
 import 'exceptions.dart';
+import 'package:platform/platform.dart';
+import 'package:meta/meta.dart';
+
+/// Wrapper around [Platform] for testing.
+Platform _platform = LocalPlatform();
 
 /// Operating System-specific constants for terminal commands, directories, etc.
 ///
-/// Supports Windows, Mac, and Linux hosts. Others will throw an [UnknownPlatformException].
+/// Supports Windows, Mac, and Linux hosts. Others will throw an
+/// [UnknownPlatformException].
 abstract class HostPlatformConfig {
+  @visibleForTesting
+  static void overridePlatform(Platform platform) {
+    _platform = platform;
+  }
+
   /// Returns the expected location for the dart pub cache.
   ///
   /// * For Unix systems this is usually a hidden folder in your home directory.
   /// * For Windows this is usually in your AppData folder.
   static String get pubCacheLocation {
-    if (Platform.isWindows) {
-      return '${Platform.environment['USERPROFILE']}\\AppData\\Local\\Pub\\Cache\\bin';
-    } else if (Platform.isMacOS || Platform.isLinux) {
-      return '${Platform.environment['HOME']}/.pub/cache/bin';
-    } else {
-      throw UnknownPlatformException();
+    switch (_platform.operatingSystem) {
+      case 'linux':
+      case 'macos':
+        return '${_platform.environment['HOME']}/.pub/cache/bin';
+      case 'windows':
+        return '${_platform.environment['USERPROFILE']}'
+            '\\AppData\\Local\\Pub\\Cache\\bin';
+      case _:
+        throw UnknownPlatformException();
     }
   }
 
   /// Returns the expected name of the `flutterfire_cli` command.
   ///
   /// * For Unix systems this is usually just `flutterfire`.
-  /// * For Windows this is usually `flutterfire.bat`, but powershell terminals allow the Unix method, too.
+  /// * For Windows this is usually `flutterfire.bat`, but powershell terminals
+  ///   allow the Unix method, too.
   static String get flutterfireCli {
-    if (Platform.isWindows) {
-      return 'flutterfire.bat';
-    } else if (Platform.isMacOS || Platform.isLinux) {
-      return 'flutterfire';
-    } else {
-      throw UnknownPlatformException();
+    switch (_platform.operatingSystem) {
+      case 'linux':
+      case 'macos':
+        return 'flutterfire';
+      case 'windows':
+        return 'flutterfire.bat';
+      case _:
+        throw UnknownPlatformException();
     }
   }
 }

--- a/bin/src/utils/host_platform.dart
+++ b/bin/src/utils/host_platform.dart
@@ -1,36 +1,35 @@
 import 'dart:io';
+import 'exceptions.dart';
 
 /// Operating System-specific constants for terminal commands, directories, etc.
 ///
 /// Supports Windows, Mac, and Linux hosts. Others will throw an [UnknownPlatformException].
 abstract class HostPlatformConfig {
-
-    /// Returns the expected location for the dart pub cache.
-    ///
-    /// * For Unix systems this is usually a hidden folder in your home directory.
-    /// * For Windows this is usually in your AppData folder.
-    static String pubCacheLocation() {
-        if (Platform.isWindows) {
-            return '%APPDATA%/Pub/Cache/bin';
-        } else if (Platform.isMac || Platform.isLinux) {
-            return '~/.pub/cache/bin';   
-        } else {
-            throw UnknownPlatformException('Unknown platform - ${Platform.operatingSystem}');
-        }
+  /// Returns the expected location for the dart pub cache.
+  ///
+  /// * For Unix systems this is usually a hidden folder in your home directory.
+  /// * For Windows this is usually in your AppData folder.
+  static String get pubCacheLocation {
+    if (Platform.isWindows) {
+      return '${Platform.environment['USERPROFILE']}\\AppData\\Local\\Pub\\Cache\\bin';
+    } else if (Platform.isMacOS || Platform.isLinux) {
+      return '${Platform.environment['HOME']}/.pub/cache/bin';
+    } else {
+      throw UnknownPlatformException();
     }
+  }
 
-    /// Returns the expected name of the `flutterfire_cli` command.
-    ///
-    /// * For Unix systems this is usually just `flutterfire`.
-    /// * For Windows this is usually `flutterfire.bat`, but powershell terminals allow the Unix method, too.
-    static String flutterfireCli() {
-        if (Platform.isWindows) {
-            return 'flutterfire.bat';    
-        } else if (Platform.isMac || Platform.isLinux) {
-            return 'flutterfire';        
-        } else {
-            throw UnknownPlatformException('Unknown platform - ${Platform.operatingSystem}');
-        }
+  /// Returns the expected name of the `flutterfire_cli` command.
+  ///
+  /// * For Unix systems this is usually just `flutterfire`.
+  /// * For Windows this is usually `flutterfire.bat`, but powershell terminals allow the Unix method, too.
+  static String get flutterfireCli {
+    if (Platform.isWindows) {
+      return 'flutterfire.bat';
+    } else if (Platform.isMacOS || Platform.isLinux) {
+      return 'flutterfire';
+    } else {
+      throw UnknownPlatformException();
     }
+  }
 }
-

--- a/bin/src/utils/host_platform.dart
+++ b/bin/src/utils/host_platform.dart
@@ -28,7 +28,7 @@ abstract class HostPlatformConfig {
         return '${_platform.environment['USERPROFILE']}'
             '\\AppData\\Local\\Pub\\Cache\\bin';
       case _:
-        throw UnknownPlatformException();
+        throw UnknownPlatformException(_platform);
     }
   }
 
@@ -45,7 +45,7 @@ abstract class HostPlatformConfig {
       case 'windows':
         return 'flutterfire.bat';
       case _:
-        throw UnknownPlatformException();
+        throw UnknownPlatformException(_platform);
     }
   }
 }

--- a/bin/src/version.dart
+++ b/bin/src/version.dart
@@ -1,3 +1,3 @@
 // Generated from pubspec.yaml by tool/sync_version.dart.
 // Do not edit by hand. Run: dart run tool/sync_version.dart
-const packageVersion = '3.0.0';
+const packageVersion = '3.1.0';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "0.12.20"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: "direct main"
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   pool:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   args: ^2.7.0
   logger: ^2.4.0
+  platform: ^3.1.6
   xcode_parser: ^2.1.0
   yaml: ^3.1.3
   yaml_edit: ^2.2.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_flavors
 description: A Dart CLI tool for configuring Firebase for multiple Flutter flavors.
-version: 3.0.0
+version: 3.1.0
 repository: https://github.com/andyhorn/firebase_flavors
 license: MIT
 
@@ -10,6 +10,7 @@ environment:
 dependencies:
   args: ^2.7.0
   logger: ^2.4.0
+  meta: ^1.18.2
   platform: ^3.1.6
   xcode_parser: ^2.1.0
   yaml: ^3.1.3

--- a/test/utils/host_platform_test.dart
+++ b/test/utils/host_platform_test.dart
@@ -1,6 +1,7 @@
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
+import '../../bin/src/utils/exceptions.dart';
 import '../../bin/src/utils/host_platform.dart';
 
 void main() {
@@ -30,5 +31,26 @@ void main() {
       HostPlatformConfig.pubCacheLocation,
       endsWith('\\AppData\\Local\\Pub\\Cache\\bin'),
     );
+  });
+
+  test('unsupported platform throws an unknown platform exception', () {
+    HostPlatformConfig.overridePlatform(
+      FakePlatform(operatingSystem: 'android'),
+    );
+
+    expect(
+      () => HostPlatformConfig.flutterfireCli,
+      throwsA(isA<UnknownPlatformException>()),
+    );
+  });
+
+  test('supported platform do not throw', () {
+    for (var platform in ['linux', 'windows', 'macos']) {
+      HostPlatformConfig.overridePlatform(
+        FakePlatform(operatingSystem: platform),
+      );
+
+      expect(() => HostPlatformConfig.flutterfireCli, returnsNormally);
+    }
   });
 }

--- a/test/utils/host_platform_test.dart
+++ b/test/utils/host_platform_test.dart
@@ -1,14 +1,34 @@
 import 'package:platform/platform.dart';
-
 import 'package:test/test.dart';
 
 import '../../bin/src/utils/host_platform.dart';
 
 void main() {
-  test('configuration changes based on platform', () {
-    // TODO override platform.
+  test('flutterfire config changes based on platform', () {
+    HostPlatformConfig.overridePlatform(FakePlatform(operatingSystem: 'macos'));
     expect(HostPlatformConfig.flutterfireCli, equals('flutterfire'));
-    // TODO override platform.
+
+    HostPlatformConfig.overridePlatform(
+      FakePlatform(operatingSystem: 'windows'),
+    );
     expect(HostPlatformConfig.flutterfireCli, equals('flutterfire.bat'));
+  });
+
+  test('pubspec cache config changes based on platform', () {
+    HostPlatformConfig.overridePlatform(
+      FakePlatform(operatingSystem: 'linux', environment: {'HOME': '/home/'}),
+    );
+    expect(HostPlatformConfig.pubCacheLocation, endsWith('/.pub/cache/bin'));
+
+    HostPlatformConfig.overridePlatform(
+      FakePlatform(
+        operatingSystem: 'windows',
+        environment: {'USERPROFILE': 'C:\\Users\\User.Name\\'},
+      ),
+    );
+    expect(
+      HostPlatformConfig.pubCacheLocation,
+      endsWith('\\AppData\\Local\\Pub\\Cache\\bin'),
+    );
   });
 }

--- a/test/utils/host_platform_test.dart
+++ b/test/utils/host_platform_test.dart
@@ -1,0 +1,14 @@
+import 'package:platform/platform.dart';
+
+import 'package:test/test.dart';
+
+import '../../bin/src/utils/host_platform.dart';
+
+void main() {
+  test('configuration changes based on platform', () {
+    // TODO override platform.
+    expect(HostPlatformConfig.flutterfireCli, equals('flutterfire'));
+    // TODO override platform.
+    expect(HostPlatformConfig.flutterfireCli, equals('flutterfire.bat'));
+  });
+}


### PR DESCRIPTION
Fixes #9 
Fixes #10

Fixed Windows support as dart process runner cannot locate '.bat' files from the PATH on Windows machines, even though this is possible via other shells (cmd.exe, powershell etc.). This enabled me to run `firebase_flavors configure ...` on my machine, and delivers the correct path to the pub cache should the command fail.

Added a helper class, `HostPlatformConfig`, for centralised management of "platform specific" constants and variables, utilising `package:meta` and `package:platform` to enable testability. Extending this class should be fairly straightforward - Just add a new getter that runs a switch statement against `_platform.operatingSystem` which you can then use to alter behavior on mac, linux, windows, and other OSes if necessary.

Unit tests have been added and verified for the new classes, and I've manually verified that the command works on Windows against my own project. You may wish to verify that it works on linux and/or macos too, but the intention on this PR was to leave the behavior unchanged for non-windows platforms.